### PR TITLE
Update code to rust2018 edition, update log dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "fstab"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Chris Holcombe <xfactor973@gmail.com>"]
 description = "An fstab parser and modifier"
+edition = "2018"
 license = "MIT"
 documentation = "https://docs.rs/fstab"
 repository = "https://github.com/cholcombe973/fstab"
 homepage = "https://github.com/cholcombe973/fstab"
 
 [dependencies]
-log = "~0.3"
+log = "~0.4"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # fstab
 [![Docs](https://docs.rs/fstab/badge.svg)](https://docs.rs/fstab)
 
-A really simple fstab parser that doesn't do much type marshalling yet.  Outside contributions are more than welcome!
+A really simple fstab parser that doesn't do much type marshaling yet. Outside contributions are more than welcome!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate log;
+use log::{debug, trace};
 
 use std::fs::File;
 use std::io::{Error, ErrorKind, Read, Write};


### PR DESCRIPTION
@cholcombe973 I'd be grateful if you could release this one! I am not sure whether we should really increment the minor version, it seems rust 2018 edition can easily work with 2015, which won't be a thing when 2015 interacts with 2018 I guess.
Well, my goal is to update the `log` crate requirement since it is too low and causes duplicate versions of it in the newer projects dependency tree.